### PR TITLE
Docusaurus: Updated versions to align to latest.

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -14,9 +14,9 @@
     "write-heading-ids": "docusaurus write-heading-ids"
   },
   "dependencies": {
-    "@docusaurus/core": "3.5.2",
-    "@docusaurus/preset-classic": "3.5.2",
-    "@docusaurus/theme-mermaid": "^3.5.2",
+    "@docusaurus/core": "^3.8.1",
+    "@docusaurus/preset-classic": "^3.8.1",
+    "@docusaurus/theme-mermaid": "^3.8.1",
     "@mdx-js/react": "^3.0.0",
     "canvas-confetti": "^1.9.3",
     "clsx": "^2.0.0",
@@ -25,8 +25,8 @@
     "react-dom": "^18.0.0"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "3.5.2",
-    "@docusaurus/types": "3.5.2"
+    "@docusaurus/module-type-aliases": "^3.8.1",
+    "@docusaurus/types": "^3.8.1"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
Prior commit hard-set Docusaurus at 3.5.2 for Core and preset-classic modules, but allowed mermaid to be higher. This caused incompatibilities on rebuild with 3.8.1. Have standardised versions so they should work together.